### PR TITLE
OSX support

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -76,7 +76,7 @@ Even if you use Emacs in macOS, ~gif-screencast~ is still available when you app
 (with-eval-after-load "gif-screencast"
   (setq gif-screencast-program "screencapture") ;; default command in macOS
   (setq gif-screencast-args '("-x")) ;; to shut-up shutter sounds by screencapture
-  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the cpatured images
+  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the captured images
 #+END_SRC
 
 Additionally, you will need a cropping program:

--- a/readme.org
+++ b/readme.org
@@ -67,3 +67,19 @@ command it to capture only part of the screen, e.g. you can restrict the capture
 to the Emacs frame with =scrot='s argument =--focused=
 
 Start recording with ~gif-screencast~!
+
+** for macOS user
+
+Even if you use Emacs in macOS, ~gif-screencast~ is still available when you apply the following setting.
+
+#+BEGIN_SRC emacs-lisp
+(with-eval-after-load "gif-screencast"
+  (setq gif-screencast-program "screencapture") ;; default command in macOS
+  (setq gif-screencast-args '("-x")) ;; to shut-up shutter sounds by screencapture
+  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the cpatured images
+#+END_SRC
+
+Additionally, you will need a cropping program:
+- ~gif-screencast-cropping-program~: [[https://imagemagick.org/script/mogrify.php][mogrify]] (from the ImageMagick suite)
+
+If [[https://imagemagick.org/script/mogrify.php][mogrify]] is not installed in your system, captured images by ~gif-screencast-program~ are not cropped.


### PR DESCRIPTION
A proposal to support OSX. see also #4.

Main changes:
 - [ ] added package `s` for better display of the output from `gif-screencast-print-status` in minibuffer, remove "\n" by chomp.
 - [ ] added `gif-screencast-capture-format` to change the capture format, PPM is required for generating GIF with cropped images correctly in OSX.
 - [ ] added `gif-screencast-title-bar-pixel-height` to adjust the height of cropped region.
 - [ ] modified `gif-screencast--finish` to crop captured images before generating GIF.
 - [ ] extracted `gif-screencast--generate-gif` from `gif-screencast--finish` to control the pipeline for cropping and converting.
 - [ ] added `gif-screencast--cropping-region` and `gif-screen--cropping` to crop captured images.
 - [ ] modified `gif-screencast-capture` to correct the arguments order for "screencapture" command, the modified order also works for "scrot".

This PR does not include a change to fix possible issue on `gif-screencast-autoremove-screenshots`.