### PR TITLE
Ensure deletion of captured images when gif-screencast-autoremove-screenshots equals t

### DIFF
--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -288,11 +288,15 @@ A screenshot is taken before every command runs."
                                         (setq p (gif-screencast-optimize output))
                                       (gif-screencast-print-status process event))))
         (set-process-sentinel p 'gif-screencast-print-status))
-      (when (and gif-screencast-autoremove-screenshots
-                 (eq (process-exit-status p) 'exit)
-                 (= (process-exit-status p) 0))
-        (dolist (f gif-screencast--frames)
-          (delete-file (cdr f)))))))
+      (if gif-screencast-autoremove-screenshots
+          (set-process-sentinel p
+                                (lambda (process _event)
+                                  (if (and (eq (process-status process) 'exit)
+                                           (= (process-exit-status process) 0))
+                                      (dolist (f gif-screencast--frames)
+                                        (delete-file (cdr f))))
+                                  (gif-screencast-print-status process event)))
+        (set-process-sentinel p 'gif-screencast-print-status)))))
 
 (provide 'gif-screencast)
 

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -191,21 +191,17 @@ If you are a macOS user, \"ppm\" should be specified."
                       ;; Delays must come after the file arguments.
                       (apply 'nconc delays)
                       (list output))))
-      (if gif-screencast-want-optimized
-          (set-process-sentinel p (lambda (process event)
-                                    (if (and (eq (process-status process) 'exit)
-                                             (= (process-exit-status process) 0))
-                                        (setq p (gif-screencast-optimize output))
-                                      (gif-screencast-print-status process event))))
-        (set-process-sentinel p 'gif-screencast-print-status))
-      (if gif-screencast-autoremove-screenshots
-          (set-process-sentinel p (lambda (process event)
-                                    (if (and (eq (process-status process) 'exit)
-                                             (= (process-exit-status process) 0))
-                                        (dolist (f gif-screencast--frames)
-                                          (delete-file (cdr f))))
-                                    (gif-screencast-print-status process event)))
-        (set-process-sentinel p 'gif-screencast-print-status)))))
+      (set-process-sentinel p (lambda (process event)
+                                (gif-screencast-print-status process event)
+                                (when (and gif-screencast-want-optimized
+                                           (eq (process-status process) 'exit)
+                                           (= (process-exit-status process) 0))
+                                  (gif-screencast-optimize output))
+                                (when (and gif-screencast-autoremove-screenshots
+                                           (eq (process-status process) 'exit)
+                                           (= (process-exit-status process) 0))
+                                  (dolist (f gif-screencast--frames)
+                                    (delete-file (cdr f)))))))))
 
 (defun gif-screencast--cropping-region ()
   "Return the cropping region of the captured image."

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -290,7 +290,7 @@ A screenshot is taken before every command runs."
         (set-process-sentinel p 'gif-screencast-print-status))
       (if gif-screencast-autoremove-screenshots
           (set-process-sentinel p
-                                (lambda (process _event)
+                                (lambda (process event)
                                   (if (and (eq (process-status process) 'exit)
                                            (= (process-exit-status process) 0))
                                       (dolist (f gif-screencast--frames)

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -199,11 +199,14 @@ If you are a macOS user, \"ppm\" should be specified."
                                         (setq p (gif-screencast-optimize output))
                                       (gif-screencast-print-status process event))))
         (set-process-sentinel p 'gif-screencast-print-status))
-      (when (and gif-screencast-autoremove-screenshots
-                 (eq (process-exit-status p) 'exit)
-                 (= (process-exit-status p) 0))
-        (dolist (f gif-screencast--frames)
-          (delete-file (cdr f)))))))
+      (if gif-screencast-autoremove-screenshots
+          (set-process-sentinel p (lambda (process event)
+                                    (if (and (eq (process-status process) 'exit)
+                                             (= (process-exit-status process) 0))
+                                        (dolist (f gif-screencast--frames)
+                                          (delete-file (cdr f))))
+                                    (gif-screencast-print-status process event)))
+        (set-process-sentinel p 'gif-screencast-print-status)))))
 
 (defun gif-screencast--cropping-region ()
   "Return the cropping region of the captured image."

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -154,8 +154,9 @@ various programs run here."
            gif-screencast-program
            (get-buffer-create gif-screencast-log)
            gif-screencast-program
-           gif-screencast-args
-           (list file))
+           (append
+            gif-screencast-args
+            (list file)))
     (push (cons (time-subtract time gif-screencast--offset) file) gif-screencast--frames)))
 
 ;;;###autoload

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -223,6 +223,15 @@ A screenshot is taken before every command runs."
       (gif-screencast--cropping)
     (gif-screencast--generate-gif nil nil)))
 
+(defun gif-screencast--cropping-region ()
+  "Cropping region on the captured image."
+  (let ((x (car (frame-position)))
+        (y (cdr (frame-position)))
+        (width (frame-pixel-width))
+        (height (+ (frame-pixel-height)
+                   gif-screencast-title-bar-pixel-height)))
+    (format "%dx%d+%d+%d" width height x y)))
+
 (defun gif-screencast--cropping ()
   "Crop the captured images to the active region of selected frame."
   (message "Cropping captured images with %s..."
@@ -235,13 +244,7 @@ A screenshot is taken before every command runs."
                   (append '("-format")
                           (list (format "%s" gif-screencast-capture-format))
                           '("-crop")
-                          (list
-                           (format "%dx%d+%d+%d"
-                                   (frame-pixel-width)
-                                   (+ (frame-pixel-height)
-                                      gif-screencast-title-bar-pixel-height)
-                                   (car (frame-position))
-                                   (cdr (frame-position))))
+                          (list (gif-screencast--cropping-region))
                           gif-screencast-cropping-args
                           (mapcar 'cdr gif-screencast--frames)))))
     (set-process-sentinel p 'gif-screencast--generate-gif)))
@@ -290,6 +293,7 @@ A screenshot is taken before every command runs."
                                         (setq p (gif-screencast-optimize output))
                                       (gif-screencast-print-status process event))))
         (set-process-sentinel p 'gif-screencast-print-status))
+
       (if gif-screencast-autoremove-screenshots
           (set-process-sentinel p
                                 (lambda (process event)

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -5,7 +5,7 @@
 ;; Author: Pierre Neidhardt <ambrevar@gmail.com>
 ;; URL: https://github.com/ambrevar/emacs-gif-screencast
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "24.4") (s "1.12"))
 ;; Keywords: multimedia, screencast
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -34,6 +34,7 @@
 ;; TODO: Capture on scrolling (e.g. program outputting to Eshell buffer).
 ;; TODO: Add support for on-screen keystroke display, e.g. screenkey.
 
+(require 's)
 (defgroup gif-screencast nil
   "Predefined configurations for `gif-screencast'."
   :group 'multimedia)
@@ -198,7 +199,7 @@ A screenshot is taken before every command runs."
 
 (defun gif-screencast-print-status (process event)
   "Output PROCESS EVENT to minibuffer."
-  (princ (format "Process '%s' %s" process event)))
+  (princ (format "Process '%s' %s" process (s-chomp event))))
 
 (defun gif-screencast-optimize (file)
   "Optimize GIF FILE asynchronously."
@@ -247,7 +248,7 @@ A screenshot is taken before every command runs."
 
 (defun gif-screencast--generate-gif (process event)
   (when process
-    (princ (format "Process '%s' %s" process event)))
+    (gif-screencast-print-status process event))
 
   (let (delays
         (index 0)

--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -5,7 +5,7 @@
 ;; Author: Pierre Neidhardt <ambrevar@gmail.com>
 ;; URL: https://github.com/ambrevar/emacs-gif-screencast
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.4") (s "1.12"))
+;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: multimedia, screencast
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -34,7 +34,6 @@
 ;; TODO: Capture on scrolling (e.g. program outputting to Eshell buffer).
 ;; TODO: Add support for on-screen keystroke display, e.g. screenkey.
 
-(require 's)
 (defgroup gif-screencast nil
   "Predefined configurations for `gif-screencast'."
   :group 'multimedia)

--- a/readme.org
+++ b/readme.org
@@ -76,7 +76,7 @@ Even if you use Emacs in macOS, ~gif-screencast~ is still available when you app
 (with-eval-after-load "gif-screencast"
   (setq gif-screencast-program "screencapture") ;; default command in macOS
   (setq gif-screencast-args '("-x")) ;; to shut-up shutter sounds by screencapture
-  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the cpatured images
+  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the captured images
 #+END_SRC
 
 Additionally, you will need a cropping program:

--- a/readme.org
+++ b/readme.org
@@ -67,3 +67,19 @@ command it to capture only part of the screen, e.g. you can restrict the capture
 to the Emacs frame with =scrot='s argument =--focused=
 
 Start recording with ~gif-screencast~!
+
+** for macOS user
+
+Even if you use Emacs in macOS, ~gif-screencast~ is still available when you apply the following setting.
+
+#+BEGIN_SRC emacs-lisp
+(with-eval-after-load "gif-screencast"
+  (setq gif-screencast-program "screencapture") ;; default command in macOS
+  (setq gif-screencast-args '("-x")) ;; to shut-up shutter sounds by screencapture
+  (setq gif-screencast-capture-format "ppm")) ;; mandatory setting to crop the cpatured images
+#+END_SRC
+
+Additionally, you will need a cropping program:
+- ~gif-screencast-cropping-program~: [[https://imagemagick.org/script/mogrify.php][mogrify]] (from the ImageMagick suite)
+
+If [[https://imagemagick.org/script/mogrify.php][mogrify]] is not installed in your system, captured images by ~gif-screencast-program~ are not cropped.


### PR DESCRIPTION
This PR is created to fix an issue on autoremove of screenshots regarding #6.
Tested in Ubuntu and also macOS.