### PR TITLE
Support tool-bar-mode when cropping region (for macOS)

### DIFF
--- a/gif-screencast.el
+++ b/gif-screencast.el
@@ -120,7 +120,7 @@ If you are a macOS user, \"ppm\" should be specified."
   :group 'gif-screencast
   :type 'string)
 
-(defcustom gif-screencast-title-bar-pixel-height 22
+(defcustom gif-screencast-title-bar-pixel-height (cdr (cdr (assoc 'title-bar-size (frame-geometry))))
   "Height of title bar for cropping screenshots."
   :group 'gif-screencast
   :type 'integer)
@@ -207,9 +207,10 @@ If you are a macOS user, \"ppm\" should be specified."
   "Return the cropping region of the captured image."
   (let ((x (car (frame-position)))
         (y (cdr (frame-position)))
-        (width (frame-pixel-width))
+        (width (car (cdr (assoc 'outer-size (frame-geometry)))))
         (height (+ (frame-pixel-height)
-                   gif-screencast-title-bar-pixel-height)))
+                   (or gif-screencast-title-bar-pixel-height 0)
+                   (cdr (cdr (assoc 'tool-bar-size (frame-geometry)))))))
     (format "%dx%d+%d+%d" width height x y)))
 
 (defun gif-screencast--crop ()


### PR DESCRIPTION
Updated `gif-screencast--cropping-region` to support `tool-bar-mode`.
Even if `tool-bar-mode` is active, updated code can handle it properly.
Confirmed in local build on NS and Emacs Mac Port.

I keep `gif-screencast-title-bar-pixel-height` for user to change the cropping height.
Combination with KeyCast[*1] for macOS, the captured images will be able to include what user are typing.

See an example, which was captured with the following setting.

```
(with-eval-after-load "gif-screencast"
  (setq gif-screencast-title-bar-pixel-height (+ 150 gif-screencast-title-bar-pixel-height)))
```

![output-2018-03-04-10 38 22](https://user-images.githubusercontent.com/136673/36941214-6b017328-1f99-11e8-8232-c86e29757cc1.gif)

[*1] https://github.com/cho45/KeyCast